### PR TITLE
CAF-2671: Parenting off latest caf-common SNAPSHOT and using…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>com.github.cafapi</groupId>
         <artifactId>caf-common</artifactId>
-        <version>1.9.0-197</version>
+        <version>1.12.0-SNAPSHOT</version>
     </parent>
 
     <groupId>com.github.jobservice</groupId>

--- a/worker-globfilter-container/pom.xml
+++ b/worker-globfilter-container/pom.xml
@@ -355,7 +355,7 @@
                         <!-- Start Rabbit image -->
                         <image>
                             <alias>rabbitmq</alias>
-                            <name>rabbitmq:3-management</name>
+                            <name>${rabbitmq.image.version}</name>
                             <run>
                                 <ports>
                                     <port>${rabbitmq.ctrl.port}:15672</port>


### PR DESCRIPTION
….rabbitmq.image.version property that it offers.

Do not merge until https://github.com/CAFapi/caf-common/pull/27 has been merged in.