### PR TITLE
US975260: Dropping remaining HPE references

### DIFF
--- a/worker-globfilter-container/README.md
+++ b/worker-globfilter-container/README.md
@@ -1,4 +1,3 @@
 # worker-globfilter-container
 
-Container image name: `rh7-artifactory.svs.hpeswlab.net:8443/caf/worker-globfilter`
 

--- a/worker-globfilter-container/worker.yaml
+++ b/worker-globfilter-container/worker.yaml
@@ -17,4 +17,4 @@
 logging:
   level: INFO
   loggers:
-    com.hpe.caf: INFO
+    com.github.jobservice: INFO


### PR DESCRIPTION
https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=975260