### PR TITLE
Add missing <name> to pom.xml

### DIFF
--- a/worker-globfilter-batch-plugin/pom.xml
+++ b/worker-globfilter-batch-plugin/pom.xml
@@ -27,6 +27,7 @@
     
     <modelVersion>4.0.0</modelVersion>
     <artifactId>worker-globfilter-batch-plugin</artifactId>
+    <name>worker-globfilter-batch-plugin</name>
 
     <dependencies>
         <dependency>

--- a/worker-globfilter-container/pom.xml
+++ b/worker-globfilter-container/pom.xml
@@ -29,6 +29,7 @@
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>
     <artifactId>worker-globfilter-container</artifactId>
+    <name>worker-globfilter-container</name>
     
     <properties>
         <worker-globfilter.container.name>${dockerJobServiceOrg}worker-globfilter${dockerProjectVersion}


### PR DESCRIPTION
This PR adds missing <name> tags to pom.xml files using their corresponding <artifactId> values, ensuring they're not added inside <parent> blocks.

https://internal.almoctane.com/ui/entity-navigation?p=131002/6001&entityType=work_item&id=1029210